### PR TITLE
ENH: Filter supplied template path

### DIFF
--- a/pmpro-email-templates.php
+++ b/pmpro-email-templates.php
@@ -468,6 +468,8 @@ function pmproet_getTemplateBody($template) {
         $file = get_stylesheet_directory() . '/paid-memberships-pro/email/' . $template . '.html';
     } elseif ( file_exists( get_template_directory() . '/paid-memberships-pro/email/' . $template . '.html') ) {
         $file = get_template_directory() . '/paid-memberships-pro/email/' . $template . '.html';
+    } elseif( isset($pmproet_email_defaults[$template]['dir_path']) && file_exists(  trailingslashit($pmproet_email_defaults[$template]['dir_path']) . $template . '.html')) {
+        $file = trailingslashit($pmproet_email_defaults[$template]['dir_path']) . $template . '.html';
     } elseif( file_exists( PMPRO_DIR . '/email/' . $template . '.html')) {
         $file = PMPRO_DIR . '/email/' . $template . '.html';
     } 


### PR DESCRIPTION
Allows specifying a 'dir_path' for the template which can be used to load a template from a plugin/addon directory as well.