### PR TITLE
Adding SCA Payment Action Required emails

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -165,6 +165,14 @@ $pmproet_email_defaults = array(
 		'subject'     => __( "Your trial at !!sitename!! is ending soon", 'pmproet' ),
 		'description' => __('Trial Ending', 'pmproet')
 	),
+	'payment_action'            => array(
+		'subject'     => __( "Payment action required for your !!sitename!! membership", 'pmproet' ),
+		'description' => __('Payment Action Required', 'pmproet')
+	),
+	'payment_action_admin'      => array(
+		'subject'     => __( "Payment action required: membership for !!user_login!! at !!sitename!!", 'pmproet' ),
+		'description' => __('Payment Action Required (admin)', 'pmproet')
+	),
 );
 
 /**

--- a/includes/init.php
+++ b/includes/init.php
@@ -165,15 +165,21 @@ $pmproet_email_defaults = array(
 		'subject'     => __( "Your trial at !!sitename!! is ending soon", 'pmproet' ),
 		'description' => __('Trial Ending', 'pmproet')
 	),
-	'payment_action'            => array(
-		'subject'     => __( "Payment action required for your !!sitename!! membership", 'pmproet' ),
-		'description' => __('Payment Action Required', 'pmproet')
-	),
-	'payment_action_admin'      => array(
-		'subject'     => __( "Payment action required: membership for !!user_login!! at !!sitename!!", 'pmproet' ),
-		'description' => __('Payment Action Required (admin)', 'pmproet')
-	),
 );
+
+// add SCA payment action required emails if we're using PMPro 2.1 or later
+if( version_compare( PMPRO_VERSION, '2.1' ) >= 0 ) {
+	$pmproet_email_defaults = array_merge( $pmproet_email_defaults, array(
+		'payment_action'            => array(
+			'subject'     => __( "Payment action required for your !!sitename!! membership", 'pmproet' ),
+			'description' => __('Payment Action Required', 'pmproet')
+		),
+		'payment_action_admin'      => array(
+			'subject'     => __( "Payment action required: membership for !!user_login!! at !!sitename!!", 'pmproet' ),
+			'description' => __('Payment Action Required (admin)', 'pmproet')
+		)
+	));
+}
 
 /**
  * Filter default template settings and add new templates.

--- a/pmpro-email-templates.php
+++ b/pmpro-email-templates.php
@@ -245,6 +245,14 @@ function pmproet_send_test() {
             $send_email = 'sendMembershipExpiringEmail';
             $params = array($test_user);
             break;
+        case 'payment_action':
+            $send_email = 'sendPaymentActionRequiredEmail';
+            $params = array($test_user, $test_order, "http://www.example-notification-url.com/not-a-real-site");
+            break;
+        case 'payment_action_admin':
+            $send_email = 'sendPaymentActionRequiredAdminEmail';
+            $params = array($test_user, $test_order, "http://www.example-notification-url.com/not-a-real-site");
+            break;
         default:
             $send_email = 'sendEmail';
             $params = array();


### PR DESCRIPTION
Added support for SCA 'payment action required' emails. Two new templates: "Payment Action Required" (payment_action.html) and "Payment Action Required (admin)" (payment_action_admin.html).

See branch https://github.com/LMNTL/paid-memberships-pro/tree/v2.1-sca-email for where the templates/functions are added.

Will only display under Memberships > Email Templates if PMPRO_VERSION >= 2.1 to so things don't break on earlier versions.