### PR TITLE
get current level for user

### DIFF
--- a/pmpro-email-templates.php
+++ b/pmpro-email-templates.php
@@ -375,7 +375,10 @@ if ( ! function_exists( 'pmproet_init' ) ) {
 			$user = get_user_by('login', $data['user_login']);
 	    if(empty($user))
 	        $user = $current_user;
-	    $pmpro_user_meta = $wpdb->get_row("SELECT * FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status='active'");
+		$pmpro_user_meta = $wpdb->get_row("SELECT * FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status='active'");
+		
+		//make sure we have the current membership level data
+		$user->membership_level = pmpro_getMembershipLevelForUser($user->ID, true);
 
 		//make sure data is an array
 		if(!is_array($data))


### PR DESCRIPTION
When setting or changing an expiration date for a user on the edit user profile page in the WordPress dashboard the user incorrectly gets emailed that their level was cancelled.

This is possibly due to not getting the correct level for the user here:
https://github.com/strangerstudios/pmpro-email-templates/blob/b4e61f0bca1cfac9614d1b33c55eb76275ed76da/pmpro-email-templates.php#L438-L442

As a workaround use the same method as class PMProEmail from PMPro core to determine the user's current level.
https://github.com/strangerstudios/paid-memberships-pro/blob/625765a0010f77a55fe4e1a6b0a6ed71fa0da788/classes/class.pmproemail.php#L858-L859