### PR TITLE
Localization update

### DIFF
--- a/adminpages/emailtemplates.php
+++ b/adminpages/emailtemplates.php
@@ -1,7 +1,7 @@
 <?php
 //only admins can get this
 if ( ! function_exists( "current_user_can" ) || ( ! current_user_can( "manage_options" ) && ! current_user_can( "pmpro_emailtemplates" ) ) ) {
-	die( __( "You do not have permissions to perform this action.", "pmproet" ) );
+	die( __( "You do not have permissions to perform this action.", "pmpro-email-templates" ) );
 }
 
 global $pmproet_test_order_id, $wpdb, $msg, $msgt, $pmproet_email_defaults, $current_user;
@@ -11,7 +11,7 @@ require_once( PMPRO_DIR . "/adminpages/admin_header.php" );
 ?>
 
 	<form action="" method="post" enctype="multipart/form-data">
-	<h2><?php _e( 'Email Templates', 'pmproet' ); ?></h2>
+	<h2><?php _e( 'Email Templates', 'pmpro-email-templates' ); ?></h2>
 	<table class="form-table">
 	<tr class="status hide-while-loading" style="display:none;">
 		<th scope="row" valign="top"></th>
@@ -29,8 +29,8 @@ require_once( PMPRO_DIR . "/adminpages/admin_header.php" );
 	<td>
 	<select name="pmpro_email_template_switcher" id="pmpro_email_template_switcher">
 	<option value="" selected="selected">--- Select a Template to Edit ---</option>
-	<option value="header"><?php _e('Email Header', 'pmproet'); ?></option>
-	<option value="footer"><?php _e('Email Footer', 'pmproet'); ?></option>
+	<option value="header"><?php _e('Email Header', 'pmpro-email-templates'); ?></option>
+	<option value="footer"><?php _e('Email Footer', 'pmpro-email-templates'); ?></option>
 	<?php foreach ( $pmproet_email_defaults as $key => $template ): ?>
 	<option value="<?php echo $key; ?>"><?php echo $template['description']; ?></option>
 	<?php endforeach; ?>
@@ -43,19 +43,19 @@ require_once( PMPRO_DIR . "/adminpages/admin_header.php" );
 		<th scope="row" valign="top"></th>
 		<td>
 			<label><input id="email_template_disable" name="email_template_disable" type="checkbox"/><span
-					id="disable_label"><?php _e('Disable this email?', 'pmproet');?></span></label>
+					id="disable_label"><?php _e('Disable this email?', 'pmpro-email-templates');?></span></label>
 
-			<p id="disable_description" class="description small"><?php _e('Emails with this template will not be sent.', 'pmproet');?></p>
+			<p id="disable_description" class="description small"><?php _e('Emails with this template will not be sent.', 'pmpro-email-templates');?></p>
 		</td>
 	</tr>
 	<tr class="hide-while-loading">
-		<th scope="row" valign="top"><label for="email_template_subject"><?php _e('Subject', 'pmproet');?></label></th>
+		<th scope="row" valign="top"><label for="email_template_subject"><?php _e('Subject', 'pmpro-email-templates');?></label></th>
 		<td>
 			<input id="email_template_subject" name="email_template_subject" type="text" size="100"/>
 		</td>
 	</tr>
 	<tr class="hide-while-loading">
-		<th scope="row" valign="top"><label for="email_template_body"><?php _e('Body', 'pmproet');?></label></th>
+		<th scope="row" valign="top"><label for="email_template_body"><?php _e('Body', 'pmpro-email-templates');?></label></th>
 		<td>
 			<div id="template_editor_container">
 				<textarea rows="10" cols="80" name="email_template_body" id="email_template_body"></textarea>
@@ -65,18 +65,18 @@ require_once( PMPRO_DIR . "/adminpages/admin_header.php" );
 	<tr class="hide-while-loading">
 		<th scope="row" valign="top"></th>
 		<td>
-			<?php _e( 'Send a test email to ', 'pmproet' ); ?>
+			<?php _e( 'Send a test email to ', 'pmpro-email-templates' ); ?>
 			<input id="test_email_address" name="test_email_address" type="text"
 			       value="<?php echo $current_user->user_email; ?>"/>
-			<input id="send_test_email" class="button" name="send_test_email" value="<?php _e('Save Template and Send Email', 'pmproet');?>"
+			<input id="send_test_email" class="button" name="send_test_email" value="<?php _e('Save Template and Send Email', 'pmpro-email-templates');?>"
 			       type="button"/>
 
 			<p class="description">
 				<a href="<?php echo add_query_arg( array( 'page'  => 'pmpro-orders',
 				                                          'order' => $pmproet_test_order_id
 				), admin_url( 'admin.php' ) ); ?>"
-				   target="_blank"><?php _e( 'Click here to edit the order used for test emails.', 'pmproet' ); ?></a>
-				<?php _e( 'Your current membership will be used for any membership level data.', 'pmproet' ); ?>
+				   target="_blank"><?php _e( 'Click here to edit the order used for test emails.', 'pmpro-email-templates' ); ?></a>
+				<?php _e( 'Your current membership will be used for any membership level data.', 'pmpro-email-templates' ); ?>
 			</p>
 		</td>
 	</tr>
@@ -94,143 +94,143 @@ require_once( PMPRO_DIR . "/adminpages/admin_header.php" );
 	<tr>
 		<th scope="row" valign="top"></th>
 		<td>
-			<h3><?php _e('Variable Reference', 'pmproet');?></h3>
+			<h3><?php _e('Variable Reference', 'pmpro-email-templates');?></h3>
 
 			<div id="template_reference" style="overflow:scroll;height:250px;width:800px;;">
 				<table class="widefat striped">
 					<tr>
-						<th colspan=2><?php _e('General Settings / Membership Info', 'pmproet');?></th>
+						<th colspan=2><?php _e('General Settings / Membership Info', 'pmpro-email-templates');?></th>
 					</tr>
 					<tr>
 						<td>!!name!!</td>
-						<td><?php _e('Display Name (Profile/Edit User > Display name publicly as)', 'pmproet');?></td>
+						<td><?php _e('Display Name (Profile/Edit User > Display name publicly as)', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!user_login!!</td>
-						<td><?php _e('Username', 'pmproet');?></td>
+						<td><?php _e('Username', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!sitename!!</td>
-						<td><?php _e('Site Title', 'pmproet');?></td>
+						<td><?php _e('Site Title', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!siteemail!!</td>
-						<td><?php _e('Site Email Address (General Settings > Email OR Memberships > Email Settings)', 'pmproet');?></td>
+						<td><?php _e('Site Email Address (General Settings > Email OR Memberships > Email Settings)', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!membership_id!!</td>
-						<td><?php _e('Membership Level ID', 'pmproet');?></td>
+						<td><?php _e('Membership Level ID', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!membership_level_name!!</td>
-						<td><?php _e('Membership Level Name', 'pmproet');?></td>
+						<td><?php _e('Membership Level Name', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!membership_change!!</td>
-						<td><?php _e('Membership Level Change', 'pmproet');?></td>
+						<td><?php _e('Membership Level Change', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!membership_expiration!!</td>
-						<td><?php _e('Membership Level Expiration', 'pmproet');?></td>
+						<td><?php _e('Membership Level Expiration', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!display_name!!</td>
-						<td><?php _e('Display Name (Profile/Edit User > Display name publicly as)', 'pmproet');?></td>
+						<td><?php _e('Display Name (Profile/Edit User > Display name publicly as)', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!enddate!!</td>
-						<td><?php _e('User Subscription End Date', 'pmproet');?></td>
+						<td><?php _e('User Subscription End Date', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!user_email!!</td>
-						<td><?php _e('User Email', 'pmproet');?></td>
+						<td><?php _e('User Email', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!login_link!!</td>
-						<td><?php _e('Login URL', 'pmproet');?></td>
+						<td><?php _e('Login URL', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!levels_link!!</td>
-						<td><?php _e('Membership Levels Page URL', 'pmproet');?></td>
+						<td><?php _e('Membership Levels Page URL', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<th colspan=2>Billing Information</th>
 					</tr>
 					<tr>
 						<td>!!billing_address!!</td>
-						<td><?php _e('Billing Info Complete Address', 'pmproet');?></td>
+						<td><?php _e('Billing Info Complete Address', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!billing_name!!</td>
-						<td><?php _e('Billing Info Name', 'pmproet');?></td>
+						<td><?php _e('Billing Info Name', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!billing_street!!</td>
-						<td><?php _e('Billing Info Street Address', 'pmproet');?></td>
+						<td><?php _e('Billing Info Street Address', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!billing_city!!</td>
-						<td><?php _e('Billing Info City', 'pmproet');?></td>
+						<td><?php _e('Billing Info City', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!billing_state!!</td>
-						<td><?php _e('Billing Info State', 'pmproet');?></td>
+						<td><?php _e('Billing Info State', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!billing_zip!!</td>
-						<td><?php _e('Billing Info ZIP Code', 'pmproet');?></td>
+						<td><?php _e('Billing Info ZIP Code', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!billing_country!!</td>
-						<td><?php _e('Billing Info Country', 'pmproet');?></td>
+						<td><?php _e('Billing Info Country', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!billing_phone!!</td>
-						<td><?php _e('Billing Info Phone #', 'pmproet');?></td>
+						<td><?php _e('Billing Info Phone #', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!cardtype!!</td>
-						<td><?php _e('Credit Card Type', 'pmproet');?></td>
+						<td><?php _e('Credit Card Type', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!accountnumber!!</td>
-						<td><?php _e('Credit Card Number (last 4 digits)', 'pmproet');?></td>
+						<td><?php _e('Credit Card Number (last 4 digits)', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!expirationmonth!!</td>
-						<td><?php _e('Credit Card Expiration Month (mm format)', 'pmproet');?></td>
+						<td><?php _e('Credit Card Expiration Month (mm format)', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!expirationyear!!</td>
-						<td><?php _e('Credit Card Expiration Year (yyyy format)', 'pmproet');?></td>
+						<td><?php _e('Credit Card Expiration Year (yyyy format)', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!membership_cost!!</td>
-						<td><?php _e('Membership Level Cost Text', 'pmproet');?></td>
+						<td><?php _e('Membership Level Cost Text', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!instructions!!</td>
-						<td><?php _e('Payment Instructions (used in Checkout - Email Template)', 'pmproet');?></td>
+						<td><?php _e('Payment Instructions (used in Checkout - Email Template)', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!invoice_id!!</td>
-						<td><?php _e('Invoice ID', 'pmproet');?></td>
+						<td><?php _e('Invoice ID', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!invoice_total!!</td>
-						<td><?php _e('Invoice Total', 'pmproet');?></td>
+						<td><?php _e('Invoice Total', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!invoice_date!!</td>
-						<td><?php _e('Invoice Date', 'pmproet');?></td>
+						<td><?php _e('Invoice Date', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!discount_code!!</td>
-						<td><?php _e('Discount Code Applied', 'pmproet');?></td>
+						<td><?php _e('Discount Code Applied', 'pmpro-email-templates');?></td>
 					</tr>
 					<tr>
 						<td>!!invoice_link!!</td>
-						<td><?php _e('Invoice Page URL', 'pmproet');?></td>
+						<td><?php _e('Invoice Page URL', 'pmpro-email-templates');?></td>
 					</tr>
 				</table>
 			</div>

--- a/includes/init.php
+++ b/includes/init.php
@@ -48,7 +48,7 @@ function pmproet_admin_init_test_order() {
 		$test_order->billing->zip        = '12345';
 		$test_order->billing->phone      = '5558675309';
 		$test_order->gateway_environment = 'sandbox';
-		$test_order->notes               = __( 'This is a test order used with the PMPro Email Templates addon.', 'pmproet' );
+		$test_order->notes               = __( 'This is a test order used with the PMPro Email Templates addon.', 'pmpro-email-templates' );
 		$test_order->saveOrder();
 		$pmproet_test_order_id = $test_order->id;
 		update_option( 'pmproet_test_order_id', $pmproet_test_order_id, 'no' );
@@ -62,108 +62,108 @@ add_action( 'admin_init', 'pmproet_admin_init_test_order'  );
  */
 $pmproet_email_defaults = array(
 	'default'                  => array(
-		'subject'     => __( "An Email From !!sitename!!", "pmproet" ),
-		'description' => __( 'Default Email', 'pmproet')
+		'subject'     => __( "An Email From !!sitename!!", "pmpro-email-templates" ),
+		'description' => __( 'Default Email', 'pmpro-email-templates')
 	),
 	'admin_change'             => array(
-		'subject'     => __( "Your membership at !!sitename!! has been changed", 'pmproet' ),
-		'description' => __( 'Admin Change', 'pmproet')
+		'subject'     => __( "Your membership at !!sitename!! has been changed", 'pmpro-email-templates' ),
+		'description' => __( 'Admin Change', 'pmpro-email-templates')
 	),
 	'admin_change_admin'       => array(
-		'subject'     => __( "Membership for !!user_login!! at !!sitename!! has been changed", 'pmproet' ),
-		'description' => __('Admin Change (admin)', 'pmproet')
+		'subject'     => __( "Membership for !!user_login!! at !!sitename!! has been changed", 'pmpro-email-templates' ),
+		'description' => __('Admin Change (admin)', 'pmpro-email-templates')
 	),
 	'billing'                  => array(
-		'subject'     => __( "Your billing information has been udpated at !!sitename!!", 'pmproet' ),
-		'description' => __('Billing', 'pmproet')
+		'subject'     => __( "Your billing information has been udpated at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Billing', 'pmpro-email-templates')
 	),
 	'billing_admin'            => array(
-		'subject'     => __( "Billing information has been udpated for !!user_login!! at !!sitename!!", 'pmproet' ),
-		'description' => __('Billing (admin)', 'pmproet')
+		'subject'     => __( "Billing information has been udpated for !!user_login!! at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Billing (admin)', 'pmpro-email-templates')
 	),
 	'billing_failure'          => array(
-		'subject'     => __( "Membership Payment Failed at !!sitename!!", 'pmproet' ),
-		'description' => __('Billing Failure', 'pmproet')
+		'subject'     => __( "Membership Payment Failed at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Billing Failure', 'pmpro-email-templates')
 	),
 	'billing_failure_admin'    => array(
-		'subject'     => __( "Membership Payment Failed For !!display_name!! at !!sitename!!", 'pmproet' ),
-		'description' => __('Billing Failure (admin)', 'pmproet')
+		'subject'     => __( "Membership Payment Failed For !!display_name!! at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Billing Failure (admin)', 'pmpro-email-templates')
 	),
 	'cancel'                   => array(
-		'subject'     => __( "Your membership at !!sitename!! has been CANCELLED", 'pmproet' ),
-		'description' => __('Cancel', 'pmproet')
+		'subject'     => __( "Your membership at !!sitename!! has been CANCELLED", 'pmpro-email-templates' ),
+		'description' => __('Cancel', 'pmpro-email-templates')
 	),
 	'cancel_admin'             => array(
-		'subject'     => __( "Membership for !!user_login!! at !!sitename!! has been CANCELLED", 'pmproet' ),
-		'description' => __('Cancel (admin)', 'pmproet')
+		'subject'     => __( "Membership for !!user_login!! at !!sitename!! has been CANCELLED", 'pmpro-email-templates' ),
+		'description' => __('Cancel (admin)', 'pmpro-email-templates')
 	),
 	'checkout_check'           => array(
-		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Check', 'pmproet')
+		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Check', 'pmpro-email-templates')
 	),
 	'checkout_check_admin'     => array(
-		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Check (admin)', 'pmproet')
+		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Check (admin)', 'pmpro-email-templates')
 	),
 	'checkout_express'         => array(
-		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - PayPal Express', 'pmproet')
+		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - PayPal Express', 'pmpro-email-templates')
 	),
 	'checkout_express_admin'   => array(
-		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - PayPal Express (admin)', 'pmproet')
+		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - PayPal Express (admin)', 'pmpro-email-templates')
 	),
 	'checkout_free'            => array(
-		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Free', 'pmproet')
+		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Free', 'pmpro-email-templates')
 	),
 	'checkout_free_admin'      => array(
-		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Free (admin)', 'pmproet')
+		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Free (admin)', 'pmpro-email-templates')
 	),
 	'checkout_freetrial'       => array(
-		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Free Trial', 'pmproet')
+		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Free Trial', 'pmpro-email-templates')
 	),
 	'checkout_freetrial_admin' => array(
-		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Free Trial (admin)', 'pmproet')
+		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Free Trial (admin)', 'pmpro-email-templates')
 	),
 	'checkout_paid'            => array(
-		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Paid', 'pmproet')
+		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Paid', 'pmpro-email-templates')
 	),
 	'checkout_paid_admin'      => array(
-		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Paid (admin)', 'pmproet')
+		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Paid (admin)', 'pmpro-email-templates')
 	),
 	'checkout_trial'           => array(
-		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Trial', 'pmproet')
+		'subject'     => __( "Your membership confirmation for !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Trial', 'pmpro-email-templates')
 	),
 	'checkout_trial_admin'     => array(
-		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmproet' ),
-		'description' => __('Checkout - Trial (admin)', 'pmproet')
+		'subject'     => __( "Member Checkout for !!membership_level_name!! at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Checkout - Trial (admin)', 'pmpro-email-templates')
 	),
 	'credit_card_expiring'     => array(
-		'subject'     => __( "Credit Card on File Expiring Soon at !!sitename!!", 'pmproet' ),
-		'description' => __('Credit Card Expiring', 'pmproet')
+		'subject'     => __( "Credit Card on File Expiring Soon at !!sitename!!", 'pmpro-email-templates' ),
+		'description' => __('Credit Card Expiring', 'pmpro-email-templates')
 	),
 	'invoice'                  => array(
-		'subject'     => __( "INVOICE for !!sitename!! membership", 'pmproet' ),
-		'description' => __('Invoice', 'pmproet')
+		'subject'     => __( "INVOICE for !!sitename!! membership", 'pmpro-email-templates' ),
+		'description' => __('Invoice', 'pmpro-email-templates')
 	),
 	'membership_expired'       => array(
-		'subject'     => __( "Your membership at !!sitename!! has ended", 'pmproet' ),
-		'description' => __('Membership Expired', 'pmproet')
+		'subject'     => __( "Your membership at !!sitename!! has ended", 'pmpro-email-templates' ),
+		'description' => __('Membership Expired', 'pmpro-email-templates')
 	),
 	'membership_expiring'      => array(
-		'subject'     => __( "Your membership at !!sitename!! will end soon", 'pmproet' ),
-		'description' => __('Membership Expiring', 'pmproet')
+		'subject'     => __( "Your membership at !!sitename!! will end soon", 'pmpro-email-templates' ),
+		'description' => __('Membership Expiring', 'pmpro-email-templates')
 	),
 	'trial_ending'             => array(
-		'subject'     => __( "Your trial at !!sitename!! is ending soon", 'pmproet' ),
-		'description' => __('Trial Ending', 'pmproet')
+		'subject'     => __( "Your trial at !!sitename!! is ending soon", 'pmpro-email-templates' ),
+		'description' => __('Trial Ending', 'pmpro-email-templates')
 	),
 );
 
@@ -171,12 +171,12 @@ $pmproet_email_defaults = array(
 if( version_compare( PMPRO_VERSION, '2.1' ) >= 0 ) {
 	$pmproet_email_defaults = array_merge( $pmproet_email_defaults, array(
 		'payment_action'            => array(
-			'subject'     => __( "Payment action required for your !!sitename!! membership", 'pmproet' ),
-			'description' => __('Payment Action Required', 'pmproet')
+			'subject'     => __( "Payment action required for your !!sitename!! membership", 'pmpro-email-templates' ),
+			'description' => __('Payment Action Required', 'pmpro-email-templates')
 		),
 		'payment_action_admin'      => array(
-			'subject'     => __( "Payment action required: membership for !!user_login!! at !!sitename!!", 'pmproet' ),
-			'description' => __('Payment Action Required (admin)', 'pmproet')
+			'subject'     => __( "Payment action required: membership for !!user_login!! at !!sitename!!", 'pmpro-email-templates' ),
+			'description' => __('Payment Action Required (admin)', 'pmpro-email-templates')
 		)
 	));
 }

--- a/languages/pmpro-email-templates.pot
+++ b/languages/pmpro-email-templates.pot
@@ -1,0 +1,454 @@
+# Copyright (C) 2021 Paid Memberships Pro
+# This file is distributed under the same license as the Paid Memberships Pro - Email Templates Add On plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: Paid Memberships Pro - Email Templates Add On 0.8.1\n"
+"Report-Msgid-Bugs-To: info@paidmembershipspro.com\n"
+"Last-Translator: Paid Memberships Pro <info@paidmembershipspro.com>\n"
+"Language-Team: Paid Memberships Pro <info@paidmembershipspro.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2021-01-30T09:01:44+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.3.0\n"
+"X-Domain: pmpro-email-templates\n"
+
+#. Plugin Name of the plugin
+msgid "Paid Memberships Pro - Email Templates Add On"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "https://www.paidmembershipspro.com/add-ons/email-templates-admin-editor/"
+msgstr ""
+
+#. Description of the plugin
+msgid "Customize member emails for Paid Memberships Pro using an interactive admin editor within the WordPress dashboard."
+msgstr ""
+
+#. Author of the plugin
+msgid "Paid Memberships Pro"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://www.paidmembershipspro.com"
+msgstr ""
+
+#: adminpages/emailtemplates.php:4
+msgid "You do not have permissions to perform this action."
+msgstr ""
+
+#: adminpages/emailtemplates.php:14
+#: pmpro-email-templates.php:50
+#: pmpro-email-templates.php:52
+#: pmpro-email-templates.php:72
+msgid "Email Templates"
+msgstr ""
+
+#: adminpages/emailtemplates.php:32
+msgid "Email Header"
+msgstr ""
+
+#: adminpages/emailtemplates.php:33
+msgid "Email Footer"
+msgstr ""
+
+#: adminpages/emailtemplates.php:46
+msgid "Disable this email?"
+msgstr ""
+
+#: adminpages/emailtemplates.php:48
+msgid "Emails with this template will not be sent."
+msgstr ""
+
+#: adminpages/emailtemplates.php:52
+msgid "Subject"
+msgstr ""
+
+#: adminpages/emailtemplates.php:58
+msgid "Body"
+msgstr ""
+
+#: adminpages/emailtemplates.php:68
+msgid "Send a test email to "
+msgstr ""
+
+#: adminpages/emailtemplates.php:71
+msgid "Save Template and Send Email"
+msgstr ""
+
+#: adminpages/emailtemplates.php:78
+msgid "Click here to edit the order used for test emails."
+msgstr ""
+
+#: adminpages/emailtemplates.php:79
+msgid "Your current membership will be used for any membership level data."
+msgstr ""
+
+#: adminpages/emailtemplates.php:97
+msgid "Variable Reference"
+msgstr ""
+
+#: adminpages/emailtemplates.php:102
+msgid "General Settings / Membership Info"
+msgstr ""
+
+#: adminpages/emailtemplates.php:106
+#: adminpages/emailtemplates.php:138
+msgid "Display Name (Profile/Edit User > Display name publicly as)"
+msgstr ""
+
+#: adminpages/emailtemplates.php:110
+msgid "Username"
+msgstr ""
+
+#: adminpages/emailtemplates.php:114
+msgid "Site Title"
+msgstr ""
+
+#: adminpages/emailtemplates.php:118
+msgid "Site Email Address (General Settings > Email OR Memberships > Email Settings)"
+msgstr ""
+
+#: adminpages/emailtemplates.php:122
+msgid "Membership Level ID"
+msgstr ""
+
+#: adminpages/emailtemplates.php:126
+msgid "Membership Level Name"
+msgstr ""
+
+#: adminpages/emailtemplates.php:130
+msgid "Membership Level Change"
+msgstr ""
+
+#: adminpages/emailtemplates.php:134
+msgid "Membership Level Expiration"
+msgstr ""
+
+#: adminpages/emailtemplates.php:142
+msgid "User Subscription End Date"
+msgstr ""
+
+#: adminpages/emailtemplates.php:146
+msgid "User Email"
+msgstr ""
+
+#: adminpages/emailtemplates.php:150
+msgid "Login URL"
+msgstr ""
+
+#: adminpages/emailtemplates.php:154
+msgid "Membership Levels Page URL"
+msgstr ""
+
+#: adminpages/emailtemplates.php:161
+msgid "Billing Info Complete Address"
+msgstr ""
+
+#: adminpages/emailtemplates.php:165
+msgid "Billing Info Name"
+msgstr ""
+
+#: adminpages/emailtemplates.php:169
+msgid "Billing Info Street Address"
+msgstr ""
+
+#: adminpages/emailtemplates.php:173
+msgid "Billing Info City"
+msgstr ""
+
+#: adminpages/emailtemplates.php:177
+msgid "Billing Info State"
+msgstr ""
+
+#: adminpages/emailtemplates.php:181
+msgid "Billing Info ZIP Code"
+msgstr ""
+
+#: adminpages/emailtemplates.php:185
+msgid "Billing Info Country"
+msgstr ""
+
+#: adminpages/emailtemplates.php:189
+msgid "Billing Info Phone #"
+msgstr ""
+
+#: adminpages/emailtemplates.php:193
+msgid "Credit Card Type"
+msgstr ""
+
+#: adminpages/emailtemplates.php:197
+msgid "Credit Card Number (last 4 digits)"
+msgstr ""
+
+#: adminpages/emailtemplates.php:201
+msgid "Credit Card Expiration Month (mm format)"
+msgstr ""
+
+#: adminpages/emailtemplates.php:205
+msgid "Credit Card Expiration Year (yyyy format)"
+msgstr ""
+
+#: adminpages/emailtemplates.php:209
+msgid "Membership Level Cost Text"
+msgstr ""
+
+#: adminpages/emailtemplates.php:213
+msgid "Payment Instructions (used in Checkout - Email Template)"
+msgstr ""
+
+#: adminpages/emailtemplates.php:217
+msgid "Invoice ID"
+msgstr ""
+
+#: adminpages/emailtemplates.php:221
+msgid "Invoice Total"
+msgstr ""
+
+#: adminpages/emailtemplates.php:225
+msgid "Invoice Date"
+msgstr ""
+
+#: adminpages/emailtemplates.php:229
+msgid "Discount Code Applied"
+msgstr ""
+
+#: adminpages/emailtemplates.php:233
+msgid "Invoice Page URL"
+msgstr ""
+
+#: includes/init.php:51
+msgid "This is a test order used with the PMPro Email Templates addon."
+msgstr ""
+
+#: includes/init.php:65
+msgid "An Email From !!sitename!!"
+msgstr ""
+
+#: includes/init.php:66
+msgid "Default Email"
+msgstr ""
+
+#: includes/init.php:69
+msgid "Your membership at !!sitename!! has been changed"
+msgstr ""
+
+#: includes/init.php:70
+msgid "Admin Change"
+msgstr ""
+
+#: includes/init.php:73
+msgid "Membership for !!user_login!! at !!sitename!! has been changed"
+msgstr ""
+
+#: includes/init.php:74
+msgid "Admin Change (admin)"
+msgstr ""
+
+#: includes/init.php:77
+msgid "Your billing information has been udpated at !!sitename!!"
+msgstr ""
+
+#: includes/init.php:78
+msgid "Billing"
+msgstr ""
+
+#: includes/init.php:81
+msgid "Billing information has been udpated for !!user_login!! at !!sitename!!"
+msgstr ""
+
+#: includes/init.php:82
+msgid "Billing (admin)"
+msgstr ""
+
+#: includes/init.php:85
+msgid "Membership Payment Failed at !!sitename!!"
+msgstr ""
+
+#: includes/init.php:86
+msgid "Billing Failure"
+msgstr ""
+
+#: includes/init.php:89
+msgid "Membership Payment Failed For !!display_name!! at !!sitename!!"
+msgstr ""
+
+#: includes/init.php:90
+msgid "Billing Failure (admin)"
+msgstr ""
+
+#: includes/init.php:93
+msgid "Your membership at !!sitename!! has been CANCELLED"
+msgstr ""
+
+#: includes/init.php:94
+msgid "Cancel"
+msgstr ""
+
+#: includes/init.php:97
+msgid "Membership for !!user_login!! at !!sitename!! has been CANCELLED"
+msgstr ""
+
+#: includes/init.php:98
+msgid "Cancel (admin)"
+msgstr ""
+
+#: includes/init.php:101
+#: includes/init.php:109
+#: includes/init.php:117
+#: includes/init.php:125
+#: includes/init.php:133
+#: includes/init.php:141
+msgid "Your membership confirmation for !!sitename!!"
+msgstr ""
+
+#: includes/init.php:102
+msgid "Checkout - Check"
+msgstr ""
+
+#: includes/init.php:105
+#: includes/init.php:113
+#: includes/init.php:121
+#: includes/init.php:129
+#: includes/init.php:137
+#: includes/init.php:145
+msgid "Member Checkout for !!membership_level_name!! at !!sitename!!"
+msgstr ""
+
+#: includes/init.php:106
+msgid "Checkout - Check (admin)"
+msgstr ""
+
+#: includes/init.php:110
+msgid "Checkout - PayPal Express"
+msgstr ""
+
+#: includes/init.php:114
+msgid "Checkout - PayPal Express (admin)"
+msgstr ""
+
+#: includes/init.php:118
+msgid "Checkout - Free"
+msgstr ""
+
+#: includes/init.php:122
+msgid "Checkout - Free (admin)"
+msgstr ""
+
+#: includes/init.php:126
+msgid "Checkout - Free Trial"
+msgstr ""
+
+#: includes/init.php:130
+msgid "Checkout - Free Trial (admin)"
+msgstr ""
+
+#: includes/init.php:134
+msgid "Checkout - Paid"
+msgstr ""
+
+#: includes/init.php:138
+msgid "Checkout - Paid (admin)"
+msgstr ""
+
+#: includes/init.php:142
+msgid "Checkout - Trial"
+msgstr ""
+
+#: includes/init.php:146
+msgid "Checkout - Trial (admin)"
+msgstr ""
+
+#: includes/init.php:149
+msgid "Credit Card on File Expiring Soon at !!sitename!!"
+msgstr ""
+
+#: includes/init.php:150
+msgid "Credit Card Expiring"
+msgstr ""
+
+#: includes/init.php:153
+msgid "INVOICE for !!sitename!! membership"
+msgstr ""
+
+#: includes/init.php:154
+msgid "Invoice"
+msgstr ""
+
+#: includes/init.php:157
+msgid "Your membership at !!sitename!! has ended"
+msgstr ""
+
+#: includes/init.php:158
+msgid "Membership Expired"
+msgstr ""
+
+#: includes/init.php:161
+msgid "Your membership at !!sitename!! will end soon"
+msgstr ""
+
+#: includes/init.php:162
+msgid "Membership Expiring"
+msgstr ""
+
+#: includes/init.php:165
+msgid "Your trial at !!sitename!! is ending soon"
+msgstr ""
+
+#: includes/init.php:166
+msgid "Trial Ending"
+msgstr ""
+
+#: includes/init.php:174
+msgid "Payment action required for your !!sitename!! membership"
+msgstr ""
+
+#: includes/init.php:175
+msgid "Payment Action Required"
+msgstr ""
+
+#: includes/init.php:178
+msgid "Payment action required: membership for !!user_login!! at !!sitename!!"
+msgstr ""
+
+#: includes/init.php:179
+msgid "Payment Action Required (admin)"
+msgstr ""
+
+#: pmpro-email-templates.php:359
+msgid "THIS IS A TEST EMAIL"
+msgstr ""
+
+#: pmpro-email-templates.php:446
+msgid "The new level is %s."
+msgstr ""
+
+#: pmpro-email-templates.php:448
+msgid "Your membership has been cancelled."
+msgstr ""
+
+#: pmpro-email-templates.php:451
+#: pmpro-email-templates.php:459
+msgid "This membership will expire on %s."
+msgstr ""
+
+#: pmpro-email-templates.php:454
+msgid "This membership does not expire."
+msgstr ""
+
+#: pmpro-email-templates.php:602
+msgid "View Documentation"
+msgstr ""
+
+#: pmpro-email-templates.php:602
+msgid "Docs"
+msgstr ""
+
+#: pmpro-email-templates.php:603
+msgid "Visit Customer Support Forum"
+msgstr ""
+
+#: pmpro-email-templates.php:603
+msgid "Support"
+msgstr ""

--- a/languages/pmpro-email-templates.pot
+++ b/languages/pmpro-email-templates.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-01-30T09:01:44+00:00\n"
+"POT-Creation-Date: 2021-01-30T09:11:55+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.3.0\n"
 "X-Domain: pmpro-email-templates\n"
@@ -420,35 +420,37 @@ msgstr ""
 msgid "THIS IS A TEST EMAIL"
 msgstr ""
 
-#: pmpro-email-templates.php:446
+#. translators: The placeholder is for the level name.
+#: pmpro-email-templates.php:447
 msgid "The new level is %s."
 msgstr ""
 
-#: pmpro-email-templates.php:448
+#: pmpro-email-templates.php:449
 msgid "Your membership has been cancelled."
 msgstr ""
 
-#: pmpro-email-templates.php:451
-#: pmpro-email-templates.php:459
+#. translators: The placeholder is for the level expiration date
+#: pmpro-email-templates.php:453
+#: pmpro-email-templates.php:461
 msgid "This membership will expire on %s."
 msgstr ""
 
-#: pmpro-email-templates.php:454
+#: pmpro-email-templates.php:456
 msgid "This membership does not expire."
 msgstr ""
 
-#: pmpro-email-templates.php:602
+#: pmpro-email-templates.php:604
 msgid "View Documentation"
 msgstr ""
 
-#: pmpro-email-templates.php:602
+#: pmpro-email-templates.php:604
 msgid "Docs"
 msgstr ""
 
-#: pmpro-email-templates.php:603
+#: pmpro-email-templates.php:605
 msgid "Visit Customer Support Forum"
 msgstr ""
 
-#: pmpro-email-templates.php:603
+#: pmpro-email-templates.php:605
 msgid "Support"
 msgstr ""

--- a/pmpro-email-templates.php
+++ b/pmpro-email-templates.php
@@ -5,6 +5,8 @@ Plugin URI: https://www.paidmembershipspro.com/add-ons/email-templates-admin-edi
 Description: Customize member emails for Paid Memberships Pro using an interactive admin editor within the WordPress dashboard.
 Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com
+Text Domain: pmpro-email-templates
+Domain Path: /languages
 Version: 0.8.1
 */
 

--- a/pmpro-email-templates.php
+++ b/pmpro-email-templates.php
@@ -442,12 +442,14 @@ if ( ! function_exists( 'pmproet_init' ) ) {
 		}        
 
 	    //membership change
-	    if(!empty($user->membership_level) && !empty($user->membership_level->ID))
+		if(!empty($user->membership_level) && !empty($user->membership_level->ID))
+			/* translators: The placeholder is for the level name. */
 	       $new_data["membership_change"] = sprintf(__("The new level is %s.", "pmpro-email-templates"), $user->membership_level->name);
 	    else
 	       $new_data["membership_change"] = __("Your membership has been cancelled.", "pmpro-email-templates");
 
-	    if(!empty($user->membership_level) && !empty($user->membership_level->enddate))
+		if(!empty($user->membership_level) && !empty($user->membership_level->enddate))
+			/* translators: The placeholder is for the level expiration date */
 	        $new_data["membership_change"] .= ". " . sprintf(__("This membership will expire on %s.", "pmpro-email-templates"), date_i18n( get_option( 'date_format' ), $user->membership_level->enddate ) );
 
 	    elseif(!empty($email->expiration_changed))

--- a/pmpro-email-templates.php
+++ b/pmpro-email-templates.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'pmproet_init' ) ) {
 		Load plugin textdomain.
 	*/
 	function pmproet_load_textdomain() {
-	  load_plugin_textdomain( 'pmproet', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' ); 
+	  load_plugin_textdomain( 'pmpro-email-templates', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' ); 
 	}
 	add_action( 'init', 'pmproet_load_textdomain' );
 
@@ -47,9 +47,9 @@ if ( ! function_exists( 'pmproet_init' ) ) {
 	    }
 	    
 	    if( version_compare( PMPRO_VERSION, '2.0' ) >= 0 ) {
-	        add_submenu_page('pmpro-dashboard', __('Email Templates', 'pmproet'), __('Email Templates', 'pmproet'), 'manage_options', 'pmpro-email-templates', 'pmproet_admin_page');
+	        add_submenu_page('pmpro-dashboard', __('Email Templates', 'pmpro-email-templates'), __('Email Templates', 'pmpro-email-templates'), 'manage_options', 'pmpro-email-templates', 'pmproet_admin_page');
 	    } else {
-	        add_submenu_page('pmpro-membershiplevels', __('Email Templates', 'pmproet'), __('Email Templates', 'pmproet'), 'manage_options', 'pmpro-email-templates', 'pmproet_admin_page');
+	        add_submenu_page('pmpro-membershiplevels', __('Email Templates', 'pmpro-email-templates'), __('Email Templates', 'pmpro-email-templates'), 'manage_options', 'pmpro-email-templates', 'pmproet_admin_page');
 	    }
 	}
 	add_action('admin_menu', 'pmproet_setup', 20);
@@ -69,7 +69,7 @@ if ( ! function_exists( 'pmproet_init' ) ) {
 		$wp_admin_bar->add_menu( array(
 		'id' => 'pmpro-email-templates',
 		'parent' => 'paid-memberships-pro',
-		'title' => __( 'Email Templates', 'pmproet'),
+		'title' => __( 'Email Templates', 'pmpro-email-templates'),
 		'href' => get_admin_url(NULL, '/admin.php?page=pmpro-email-templates') ) );	
 	}
 	add_action('admin_bar_menu', 'pmproet_admin_bar_menu', 1000);
@@ -356,7 +356,7 @@ if ( ! function_exists( 'pmproet_init' ) ) {
 
 	//for test emails
 	function pmproet_test_email_body($body, $email = null) {
-	    $body .= '<br><br><b>--- ' . __('THIS IS A TEST EMAIL', 'pmproet') . ' --</b>';
+	    $body .= '<br><br><b>--- ' . __('THIS IS A TEST EMAIL', 'pmpro-email-templates') . ' --</b>';
 	    return $body;
 	}
 
@@ -443,20 +443,20 @@ if ( ! function_exists( 'pmproet_init' ) ) {
 
 	    //membership change
 	    if(!empty($user->membership_level) && !empty($user->membership_level->ID))
-	       $new_data["membership_change"] = sprintf(__("The new level is %s.", "pmproet"), $user->membership_level->name);
+	       $new_data["membership_change"] = sprintf(__("The new level is %s.", "pmpro-email-templates"), $user->membership_level->name);
 	    else
-	       $new_data["membership_change"] = __("Your membership has been cancelled.", "pmproet");
+	       $new_data["membership_change"] = __("Your membership has been cancelled.", "pmpro-email-templates");
 
 	    if(!empty($user->membership_level) && !empty($user->membership_level->enddate))
-	        $new_data["membership_change"] .= ". " . sprintf(__("This membership will expire on %s.", "pmproet"), date_i18n( get_option( 'date_format' ), $user->membership_level->enddate ) );
+	        $new_data["membership_change"] .= ". " . sprintf(__("This membership will expire on %s.", "pmpro-email-templates"), date_i18n( get_option( 'date_format' ), $user->membership_level->enddate ) );
 
 	    elseif(!empty($email->expiration_changed))
-	        $new_data["membership_change"] .= ". " . __("This membership does not expire.", "pmproet");
+	        $new_data["membership_change"] .= ". " . __("This membership does not expire.", "pmpro-email-templates");
 
 	    //membership expiration
 	    $new_data['membership_expiration'] = '';
 	    if(!empty($pmpro_user_meta->enddate)) {
-	        $new_data['membership_expiration'] = "<p>" . sprintf( __("This membership will expire on %s.", "pmproet"), date_i18n( get_option( 'date_format' ), $user->membership_level->enddate ) ) . "</p>\n";
+	        $new_data['membership_expiration'] = "<p>" . sprintf( __("This membership will expire on %s.", "pmpro-email-templates"), date_i18n( get_option( 'date_format' ), $user->membership_level->enddate ) ) . "</p>\n";
 	    }
 
 	    //if others are used in the email look in usermeta
@@ -599,8 +599,8 @@ if ( ! function_exists( 'pmproet_init' ) ) {
 		if(strpos($file, 'pmpro-email-templates.php') !== false)
 		{
 			$new_links = array(
-				'<a href="' . esc_url('https://www.paidmembershipspro.com/add-ons/email-templates-admin-editor/')  . '" title="' . esc_attr( __( 'View Documentation', 'pmproet' ) ) . '">' . __( 'Docs', 'pmproet' ) . '</a>',
-				'<a href="' . esc_url('https://paidmembershipspro.com/support/') . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmproet' ) ) . '">' . __( 'Support', 'pmproet' ) . '</a>',
+				'<a href="' . esc_url('https://www.paidmembershipspro.com/add-ons/email-templates-admin-editor/')  . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-email-templates' ) ) . '">' . __( 'Docs', 'pmpro-email-templates' ) . '</a>',
+				'<a href="' . esc_url('https://paidmembershipspro.com/support/') . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-email-templates' ) ) . '">' . __( 'Support', 'pmpro-email-templates' ) . '</a>',
 			);
 			$links = array_merge($links, $new_links);
 		}

--- a/pmpro-email-templates.php
+++ b/pmpro-email-templates.php
@@ -36,7 +36,7 @@ if ( ! function_exists( 'pmproet_init' ) ) {
 	function pmproet_load_textdomain() {
 	  load_plugin_textdomain( 'pmproet', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' ); 
 	}
-	add_action( 'plugins_loaded', 'pmproet_load_textdomain' );
+	add_action( 'init', 'pmproet_load_textdomain' );
 
 	/*
 	 * Setup admin pages


### PR DESCRIPTION
This  should fix https://github.com/strangerstudios/pmpro-email-templates/issues/56

GlotPress reporting "This plugin is not properly prepared for localization". This is most probably due to the plugin header missing the Text Domain.

This PR includes:

- Add `Domain Path` to plugin header.
- Add `Text Domain` as plugin [slug](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains) to plugin header.
- Change text domain from `pmproet` to `pmpro-email-templates`.
- Add translators notes for placeholders in text strings.
- Create language `pmpro-email-templates.pot` file

Notes:

- Existing French Language Pack not synced and updated in the pull request.
- `pmproet.pot` should be redundant after merge and removing it should be taken under consideration.
