### PR TITLE
check if PMPRO_VERSION constant is defined first

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -168,7 +168,7 @@ $pmproet_email_defaults = array(
 );
 
 // add SCA payment action required emails if we're using PMPro 2.1 or later
-if( version_compare( PMPRO_VERSION, '2.1' ) >= 0 ) {
+if( defined( 'PMPRO_VERSION' ) && version_compare( PMPRO_VERSION, '2.1' ) >= 0 ) {
 	$pmproet_email_defaults = array_merge( $pmproet_email_defaults, array(
 		'payment_action'            => array(
 			'subject'     => __( "Payment action required for your !!sitename!! membership", 'pmproet' ),


### PR DESCRIPTION
fixes: https://github.com/strangerstudios/pmpro-email-templates/issues/52

Added a check if constant `PMPRO_VERSION` is defined before comparing versions.